### PR TITLE
Update remote-state.tf to fit build order

### DIFF
--- a/ec2/remote-state.tf
+++ b/ec2/remote-state.tf
@@ -27,16 +27,16 @@ data "terraform_remote_state" "cporacle_security_groups" {
     region = var.region
   }
 }
-
-data "terraform_remote_state" "alb" {
-  backend = "s3"
-
-  config = {
-    bucket = var.remote_state_bucket_name
-    key    = "cp-oracle/alb/terraform.tfstate"
-    region = var.region
-  }
-}
+//This is not available due to build order
+//data "terraform_remote_state" "alb" {
+//  backend = "s3"
+//
+//  config = {
+//    bucket = var.remote_state_bucket_name
+//    key    = "cp-oracle/alb/terraform.tfstate"
+//    region = var.region
+//  }
+//}
 
 
 data "terraform_remote_state" "core_vpc" {


### PR DESCRIPTION
Remote state for ALBs are not available in specified build order. Commenting out to resolve.