### PR TITLE
Commenting out references due to build order.

### DIFF
--- a/ec2/asg-api.tf
+++ b/ec2/asg-api.tf
@@ -93,7 +93,7 @@ resource "aws_autoscaling_group" "cporacle_api" {
   health_check_grace_period = 600
   health_check_type         = "ELB"
 
-  target_group_arns = [local.api_target_group_arn]
+  #target_group_arns = [local.api_target_group_arn]
 
   launch_template {
     id      = aws_launch_template.cporacle_api.id

--- a/ec2/asg-website.tf
+++ b/ec2/asg-website.tf
@@ -93,7 +93,7 @@ resource "aws_autoscaling_group" "cporacle_app" {
   health_check_grace_period = 600
   health_check_type         = "ELB"
 
-  target_group_arns = [local.web_target_group_arn]
+  #target_group_arns = [local.web_target_group_arn]
 
   launch_template {
     id      = aws_launch_template.cporacle_app.id

--- a/ec2/locals.tf
+++ b/ec2/locals.tf
@@ -62,8 +62,8 @@ locals {
   # #------------------------------------
   #target_group_name   = "${local.common_name}-app-asg-target-group"
   #target_group_sticky = false
-  web_target_group_arn = data.terraform_remote_state.alb.outputs.alb_target_group_web["arn"]
-  api_target_group_arn = data.terraform_remote_state.alb.outputs.alb_target_group_api["arn"]
+  #web_target_group_arn = data.terraform_remote_state.alb.outputs.alb_target_group_web["arn"]
+  #api_target_group_arn = data.terraform_remote_state.alb.outputs.alb_target_group_api["arn"]
   # health_check_target_group_path = "/"
 
   # target_group_port = 80


### PR DESCRIPTION
 These look redundant.