### PR TITLE
Removing unused RDS role in KMS policy for PROD

### DIFF
--- a/rds/policies/kms-policy-cr-unpaid-work-prod.json
+++ b/rds/policies/kms-policy-cr-unpaid-work-prod.json
@@ -45,8 +45,7 @@
                 "AWS": [
                     "arn:aws:iam::${accountID}:role/terraform",
                     "arn:aws:iam::${accountID}:role/admin",
-                    "arn:aws:iam::${accountID}:role/cp-oracle-ec2-role",
-                    "arn:aws:iam::${accountID}:role/cp-oracle-rds-role"
+                    "arn:aws:iam::${accountID}:role/cp-oracle-ec2-role"
                 ]
             },
             "Action": [


### PR DESCRIPTION
Not sure why Chris put this in Prod and not Dev. Causing Terraform RDS component to fail.